### PR TITLE
Upgrade RuntimeAsset to v1 world-class contract

### DIFF
--- a/examples/runtime-asset.example.json
+++ b/examples/runtime-asset.example.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "lattice.socioprophet.dev/v0",
+  "apiVersion": "lattice.socioprophet.dev/v1",
   "kind": "RuntimeAsset",
   "metadata": {
     "name": "prophet-python-ml",
@@ -18,30 +18,31 @@
       "system": "mixed",
       "entrypoint": "runtimes/prophet-python-ml/flake.nix",
       "lockfile": "runtimes/prophet-python-ml/flake.lock",
-      "sourceRef": "local"
+      "sourceRef": "local",
+      "builderId": "lattice-forge-demo-builder"
     },
     "artifacts": [
-      {
-        "name": "prophet-python-ml-image",
-        "role": "oci-image",
-        "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
-      },
-      {
-        "name": "prophet-python-ml-sbom",
-        "role": "sbom",
-        "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
-      }
+      {"name": "runtime-image", "role": "oci-image", "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"},
+      {"name": "runtime-sbom", "role": "sbom", "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333"}
     ],
     "provenance": {
-      "sbomRequired": true,
-      "signatureRequired": true,
-      "evidenceReports": ["lockfile-hash", "sbom-ref", "image-digest", "package-manifest", "scan-result", "signature", "builder-id"]
+      "attestations": ["slsa", "in-toto"],
+      "sourceRefs": ["local-source-ref"],
+      "builderId": "lattice-forge-demo-builder"
     },
-    "policy": {
-      "network": "restricted",
-      "secrets": "scoped",
-      "accelerators": ["cpu"],
-      "defaultIsolation": "container"
-    }
+    "sbom": {
+      "formats": ["spdx", "cyclonedx"],
+      "digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555"
+    },
+    "signature": {
+      "type": "sigstore",
+      "bundleRef": "demo-bundle",
+      "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+    },
+    "scan": {"vulnerability": "pass", "license": "pass", "policy": "pass"},
+    "policy": {"network": "restricted", "secrets": "scoped", "accelerators": ["cpu"], "defaultIsolation": "container"},
+    "compatibility": {"surfaces": ["jupyter", "ray", "beam", "agentplane", "sourceos-user", "prophet-platform"]},
+    "telemetry": {"traceRequired": true, "metricSet": ["build-duration", "scan-duration", "artifact-size", "promotion-result"]},
+    "promotion": {"channel": "dev", "rollbackRef": "runtime/prophet-python-ml/0.0.1"}
   }
 }

--- a/schemas/runtime-asset.schema.json
+++ b/schemas/runtime-asset.schema.json
@@ -1,105 +1,32 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.socioprophet.dev/lattice-forge/runtime-asset.v0.schema.json",
-  "title": "RuntimeAsset v0",
+  "$id": "https://schemas.socioprophet.dev/lattice-forge/runtime-asset.v1.schema.json",
+  "title": "RuntimeAsset v1",
   "type": "object",
   "additionalProperties": false,
   "required": ["apiVersion", "kind", "metadata", "spec"],
   "properties": {
-    "apiVersion": {"const": "lattice.socioprophet.dev/v0"},
+    "apiVersion": {"const": "lattice.socioprophet.dev/v1"},
     "kind": {"const": "RuntimeAsset"},
-    "metadata": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["name", "version", "createdAt"],
-      "properties": {
-        "name": {"type": "string", "pattern": "^[a-z0-9][a-z0-9.-]{1,62}$"},
-        "version": {"type": "string", "pattern": "^v?[0-9]+\\.[0-9]+\\.[0-9]+([-.+][A-Za-z0-9.-]+)?$"},
-        "createdAt": {"type": "string", "format": "date-time"},
-        "labels": {"type": "object", "additionalProperties": {"type": "string"}}
-      }
-    },
+    "metadata": {"type": "object", "additionalProperties": false, "required": ["name", "version", "createdAt"], "properties": {"name": {"type": "string", "pattern": "^[a-z0-9][a-z0-9.-]{1,62}$"}, "version": {"type": "string", "pattern": "^v?[0-9]+\\.[0-9]+\\.[0-9]+([-.+][A-Za-z0-9.-]+)?$"}, "createdAt": {"type": "string", "format": "date-time"}, "labels": {"type": "object", "additionalProperties": {"type": "string"}}}},
     "spec": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["runtimeClass", "languages", "build", "artifacts", "provenance", "policy"],
+      "required": ["runtimeClass", "languages", "build", "artifacts", "provenance", "sbom", "signature", "scan", "policy", "compatibility", "telemetry", "promotion"],
       "properties": {
-        "runtimeClass": {
-          "type": "string",
-          "enum": ["notebook", "agent", "ray", "beam", "cli", "system-tool", "base-image"]
-        },
-        "languages": {
-          "type": "array",
-          "items": {"enum": ["python", "r", "go", "rust", "javascript", "typescript", "shell", "sql"]},
-          "minItems": 1,
-          "uniqueItems": true
-        },
-        "channels": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": ["name", "type"],
-            "properties": {
-              "name": {"type": "string"},
-              "type": {"enum": ["nixpkgs", "conda-forge", "prophet", "pypi", "go-module", "oci", "other"]},
-              "uri": {"type": "string"},
-              "trusted": {"type": "boolean"}
-            }
-          }
-        },
-        "build": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["system", "entrypoint"],
-          "properties": {
-            "system": {"enum": ["nix", "conda-lock", "oci", "script", "mixed"]},
-            "entrypoint": {"type": "string"},
-            "lockfile": {"type": "string"},
-            "sourceRef": {"type": "string"}
-          }
-        },
-        "artifacts": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": ["name", "role", "digest"],
-            "properties": {
-              "name": {"type": "string"},
-              "role": {"enum": ["nix-closure", "conda-env", "oci-image", "kernel-spec", "sbom", "lockfile", "signature", "archive", "other"]},
-              "digest": {"type": "string", "pattern": "^sha256:[a-fA-F0-9]{64}$"},
-              "uri": {"type": "string"},
-              "mediaType": {"type": "string"}
-            }
-          }
-        },
-        "provenance": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["sbomRequired", "signatureRequired", "evidenceReports"],
-          "properties": {
-            "sbomRequired": {"type": "boolean"},
-            "signatureRequired": {"type": "boolean"},
-            "evidenceReports": {
-              "type": "array",
-              "items": {"enum": ["lockfile-hash", "sbom-ref", "image-digest", "package-manifest", "scan-result", "signature", "builder-id"]},
-              "uniqueItems": true
-            }
-          }
-        },
-        "policy": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["network", "secrets", "accelerators", "defaultIsolation"],
-          "properties": {
-            "network": {"enum": ["none", "restricted", "full"]},
-            "secrets": {"enum": ["none", "scoped", "project", "workspace"]},
-            "accelerators": {"type": "array", "items": {"enum": ["cpu", "gpu", "neural-engine", "tpu"]}, "uniqueItems": true},
-            "defaultIsolation": {"enum": ["container", "vm", "layered", "microvm"]}
-          }
-        }
+        "runtimeClass": {"enum": ["notebook", "agent", "ray", "beam", "cli", "system-tool", "base-image"]},
+        "languages": {"type": "array", "items": {"enum": ["python", "r", "go", "rust", "javascript", "typescript", "shell", "sql"]}, "minItems": 1, "uniqueItems": true},
+        "channels": {"type": "array", "items": {"type": "object", "additionalProperties": false, "required": ["name", "type"], "properties": {"name": {"type": "string"}, "type": {"enum": ["nixpkgs", "conda-forge", "prophet", "pypi", "go-module", "oci", "other"]}, "uri": {"type": "string"}, "trusted": {"type": "boolean"}}}},
+        "build": {"type": "object", "additionalProperties": false, "required": ["system", "entrypoint", "builderId"], "properties": {"system": {"enum": ["nix", "conda-lock", "oci", "script", "mixed"]}, "entrypoint": {"type": "string"}, "lockfile": {"type": "string"}, "sourceRef": {"type": "string"}, "builderId": {"type": "string"}}},
+        "artifacts": {"type": "array", "minItems": 1, "items": {"type": "object", "additionalProperties": false, "required": ["name", "role", "digest"], "properties": {"name": {"type": "string"}, "role": {"enum": ["nix-closure", "conda-env", "oci-image", "kernel-spec", "sbom", "lockfile", "signature", "attestation", "scan-report", "archive", "other"]}, "digest": {"type": "string", "pattern": "^sha256:[a-fA-F0-9]{64}$"}, "uri": {"type": "string"}, "mediaType": {"type": "string"}}}},
+        "provenance": {"type": "object", "additionalProperties": false, "required": ["attestations", "sourceRefs", "builderId"], "properties": {"attestations": {"type": "array", "items": {"enum": ["slsa", "in-toto"]}, "minItems": 1, "uniqueItems": true}, "sourceRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1}, "builderId": {"type": "string"}}},
+        "sbom": {"type": "object", "additionalProperties": false, "required": ["formats", "digest"], "properties": {"formats": {"type": "array", "items": {"enum": ["spdx", "cyclonedx"]}, "minItems": 1, "uniqueItems": true}, "digest": {"type": "string", "pattern": "^sha256:[a-fA-F0-9]{64}$"}, "uri": {"type": "string"}}},
+        "signature": {"type": "object", "additionalProperties": false, "required": ["type", "digest"], "properties": {"type": {"enum": ["sigstore", "cosign", "minisign", "x509", "other"]}, "bundleRef": {"type": "string"}, "digest": {"type": "string", "pattern": "^sha256:[a-fA-F0-9]{64}$"}}},
+        "scan": {"type": "object", "additionalProperties": false, "required": ["vulnerability", "license", "policy"], "properties": {"vulnerability": {"enum": ["not-run", "pass", "warn", "fail"]}, "license": {"enum": ["not-run", "pass", "warn", "fail"]}, "policy": {"enum": ["not-run", "pass", "warn", "fail"]}}},
+        "policy": {"type": "object", "additionalProperties": false, "required": ["network", "secrets", "accelerators", "defaultIsolation"], "properties": {"network": {"enum": ["none", "restricted", "full"]}, "secrets": {"enum": ["none", "scoped", "project", "workspace"]}, "accelerators": {"type": "array", "items": {"enum": ["cpu", "gpu", "neural-engine", "tpu"]}, "uniqueItems": true}, "defaultIsolation": {"enum": ["container", "vm", "layered", "microvm"]}}},
+        "compatibility": {"type": "object", "additionalProperties": false, "required": ["surfaces"], "properties": {"surfaces": {"type": "array", "items": {"enum": ["jupyter", "ray", "beam", "agentplane", "sourceos-user", "sourceos-agent", "cloudshell-fog", "prophet-platform"]}, "minItems": 1, "uniqueItems": true}}},
+        "telemetry": {"type": "object", "additionalProperties": false, "required": ["traceRequired", "metricSet"], "properties": {"traceRequired": {"type": "boolean"}, "metricSet": {"type": "array", "items": {"enum": ["build-duration", "scan-duration", "artifact-size", "promotion-result"]}, "uniqueItems": true}}},
+        "promotion": {"type": "object", "additionalProperties": false, "required": ["channel", "rollbackRef"], "properties": {"channel": {"enum": ["dev", "staging", "stable", "emergency", "deprecated"]}, "rollbackRef": {"type": "string"}, "expiresAt": {"type": "string", "format": "date-time"}}}
       }
     }
   }

--- a/src/lattice_forge/validate_runtime_asset.py
+++ b/src/lattice_forge/validate_runtime_asset.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Validate RuntimeAsset documents.
 
-The first-pass validator is dependency-light so CI can validate contracts before
-we add a full schema runtime and build graph.
+The validator intentionally remains dependency-light for CI while enforcing the
+v1 world-class contract fields: provenance, SBOM, signature, scan,
+compatibility, telemetry, and promotion.
 """
 
 from __future__ import annotations
@@ -20,17 +21,27 @@ RUNTIME_CLASSES = {"notebook", "agent", "ray", "beam", "cli", "system-tool", "ba
 LANGUAGES = {"python", "r", "go", "rust", "javascript", "typescript", "shell", "sql"}
 CHANNEL_TYPES = {"nixpkgs", "conda-forge", "prophet", "pypi", "go-module", "oci", "other"}
 BUILD_SYSTEMS = {"nix", "conda-lock", "oci", "script", "mixed"}
-ARTIFACT_ROLES = {"nix-closure", "conda-env", "oci-image", "kernel-spec", "sbom", "lockfile", "signature", "archive", "other"}
-EVIDENCE_REPORTS = {"lockfile-hash", "sbom-ref", "image-digest", "package-manifest", "scan-result", "signature", "builder-id"}
+ARTIFACT_ROLES = {"nix-closure", "conda-env", "oci-image", "kernel-spec", "sbom", "lockfile", "signature", "attestation", "scan-report", "archive", "other"}
+ATTESTATIONS = {"slsa", "in-toto"}
+SBOM_FORMATS = {"spdx", "cyclonedx"}
+SIGNATURE_TYPES = {"sigstore", "cosign", "minisign", "x509", "other"}
+SCAN_RESULTS = {"not-run", "pass", "warn", "fail"}
 NETWORK = {"none", "restricted", "full"}
 SECRET_SCOPES = {"none", "scoped", "project", "workspace"}
 ACCELERATORS = {"cpu", "gpu", "neural-engine", "tpu"}
 ISOLATION = {"container", "vm", "layered", "microvm"}
+SURFACES = {"jupyter", "ray", "beam", "agentplane", "sourceos-user", "sourceos-agent", "cloudshell-fog", "prophet-platform"}
+METRICS = {"build-duration", "scan-duration", "artifact-size", "promotion-result"}
+CHANNELS = {"dev", "staging", "stable", "emergency", "deprecated"}
 
 
 def require(condition: bool, message: str) -> None:
     if not condition:
         raise ValueError(message)
+
+
+def require_string(value: object, field: str) -> None:
+    require(isinstance(value, str) and bool(value), f"{field} must be a non-empty string")
 
 
 def require_enum_list(values: object, allowed: set[str], field: str) -> None:
@@ -42,14 +53,14 @@ def require_enum_list(values: object, allowed: set[str], field: str) -> None:
 
 
 def validate_document(doc: dict) -> None:
-    require(doc.get("apiVersion") == "lattice.socioprophet.dev/v0", "apiVersion must be lattice.socioprophet.dev/v0")
+    require(doc.get("apiVersion") == "lattice.socioprophet.dev/v1", "apiVersion must be lattice.socioprophet.dev/v1")
     require(doc.get("kind") == "RuntimeAsset", "kind must be RuntimeAsset")
 
     metadata = doc.get("metadata")
     require(isinstance(metadata, dict), "metadata must be an object")
     require(NAME_RE.match(metadata.get("name", "")) is not None, "metadata.name is invalid")
     require(VERSION_RE.match(metadata.get("version", "")) is not None, "metadata.version is invalid")
-    require(isinstance(metadata.get("createdAt"), str), "metadata.createdAt is required")
+    require_string(metadata.get("createdAt"), "metadata.createdAt")
 
     spec = doc.get("spec")
     require(isinstance(spec, dict), "spec must be an object")
@@ -61,7 +72,7 @@ def validate_document(doc: dict) -> None:
     for index, channel in enumerate(channels):
         prefix = f"spec.channels[{index}]"
         require(isinstance(channel, dict), f"{prefix} must be an object")
-        require(isinstance(channel.get("name"), str) and channel["name"], f"{prefix}.name is required")
+        require_string(channel.get("name"), f"{prefix}.name")
         require(channel.get("type") in CHANNEL_TYPES, f"{prefix}.type is invalid")
         if "trusted" in channel:
             require(isinstance(channel["trusted"], bool), f"{prefix}.trusted must be a boolean")
@@ -69,22 +80,39 @@ def validate_document(doc: dict) -> None:
     build = spec.get("build")
     require(isinstance(build, dict), "spec.build must be an object")
     require(build.get("system") in BUILD_SYSTEMS, "spec.build.system is invalid")
-    require(isinstance(build.get("entrypoint"), str) and build["entrypoint"], "spec.build.entrypoint is required")
+    require_string(build.get("entrypoint"), "spec.build.entrypoint")
+    require_string(build.get("builderId"), "spec.build.builderId")
 
     artifacts = spec.get("artifacts")
     require(isinstance(artifacts, list) and artifacts, "spec.artifacts must be a non-empty list")
     for index, artifact in enumerate(artifacts):
         prefix = f"spec.artifacts[{index}]"
         require(isinstance(artifact, dict), f"{prefix} must be an object")
-        require(isinstance(artifact.get("name"), str) and artifact["name"], f"{prefix}.name is required")
+        require_string(artifact.get("name"), f"{prefix}.name")
         require(artifact.get("role") in ARTIFACT_ROLES, f"{prefix}.role is invalid")
         require(SHA256_RE.match(artifact.get("digest", "")) is not None, f"{prefix}.digest must be sha256:<64 hex chars>")
 
     provenance = spec.get("provenance")
     require(isinstance(provenance, dict), "spec.provenance must be an object")
-    require(isinstance(provenance.get("sbomRequired"), bool), "spec.provenance.sbomRequired must be a boolean")
-    require(isinstance(provenance.get("signatureRequired"), bool), "spec.provenance.signatureRequired must be a boolean")
-    require_enum_list(provenance.get("evidenceReports"), EVIDENCE_REPORTS, "spec.provenance.evidenceReports")
+    require_enum_list(provenance.get("attestations"), ATTESTATIONS, "spec.provenance.attestations")
+    require(isinstance(provenance.get("sourceRefs"), list) and provenance["sourceRefs"], "spec.provenance.sourceRefs must be a non-empty list")
+    require_string(provenance.get("builderId"), "spec.provenance.builderId")
+
+    sbom = spec.get("sbom")
+    require(isinstance(sbom, dict), "spec.sbom must be an object")
+    require_enum_list(sbom.get("formats"), SBOM_FORMATS, "spec.sbom.formats")
+    require(SHA256_RE.match(sbom.get("digest", "")) is not None, "spec.sbom.digest must be sha256:<64 hex chars>")
+
+    signature = spec.get("signature")
+    require(isinstance(signature, dict), "spec.signature must be an object")
+    require(signature.get("type") in SIGNATURE_TYPES, "spec.signature.type is invalid")
+    require(SHA256_RE.match(signature.get("digest", "")) is not None, "spec.signature.digest must be sha256:<64 hex chars>")
+
+    scan = spec.get("scan")
+    require(isinstance(scan, dict), "spec.scan must be an object")
+    require(scan.get("vulnerability") in SCAN_RESULTS, "spec.scan.vulnerability is invalid")
+    require(scan.get("license") in SCAN_RESULTS, "spec.scan.license is invalid")
+    require(scan.get("policy") in SCAN_RESULTS, "spec.scan.policy is invalid")
 
     policy = spec.get("policy")
     require(isinstance(policy, dict), "spec.policy must be an object")
@@ -92,6 +120,20 @@ def validate_document(doc: dict) -> None:
     require(policy.get("secrets") in SECRET_SCOPES, "spec.policy.secrets is invalid")
     require_enum_list(policy.get("accelerators"), ACCELERATORS, "spec.policy.accelerators")
     require(policy.get("defaultIsolation") in ISOLATION, "spec.policy.defaultIsolation is invalid")
+
+    compatibility = spec.get("compatibility")
+    require(isinstance(compatibility, dict), "spec.compatibility must be an object")
+    require_enum_list(compatibility.get("surfaces"), SURFACES, "spec.compatibility.surfaces")
+
+    telemetry = spec.get("telemetry")
+    require(isinstance(telemetry, dict), "spec.telemetry must be an object")
+    require(isinstance(telemetry.get("traceRequired"), bool), "spec.telemetry.traceRequired must be a boolean")
+    require_enum_list(telemetry.get("metricSet"), METRICS, "spec.telemetry.metricSet")
+
+    promotion = spec.get("promotion")
+    require(isinstance(promotion, dict), "spec.promotion must be an object")
+    require(promotion.get("channel") in CHANNELS, "spec.promotion.channel is invalid")
+    require_string(promotion.get("rollbackRef"), "spec.promotion.rollbackRef")
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
## Summary

Upgrades RuntimeAsset from the initial v0 scaffold to a v1 world-class baseline for governed runtime distribution.

## What changed

- `apiVersion` moves to `lattice.socioprophet.dev/v1`.
- RuntimeAsset now requires world-class runtime provenance and governance fields:
  - `provenance` for SLSA/in-toto-style build chain evidence
  - `sbom` for SPDX/CycloneDX references
  - `signature` for Sigstore/cosign/minisign/x509-compatible signing references
  - `scan` for vulnerability/license/policy scan results
  - `compatibility` for notebook/Ray/Beam/AgentPlane/SourceOS/platform consumption
  - `telemetry` for OpenTelemetry-oriented trace/metric expectations
  - `promotion` for channel and rollback governance
- Example RuntimeAsset updated to v1.
- Validator now enforces the new required fields.

## Why

This prevents Lattice Forge from stopping at runtime metadata. Every promoted runtime must prove what it contains, who built it, which SBOM and scan apply, which signature proves it, where it can run, and how it can roll back.

## Integration impact

- `prophet-platform` can consume RuntimeAsset v1 for runtime catalog and notebook/agent selection.
- `sourceos-spec` should absorb this schema family once reviewed.
- `agentplane` and `cloudshell-fog` should target this handoff object for runtime selection.

## Validation

CI should run the validator against `examples/*.json` and execute the smoke test.
