### PR TITLE
Add Prophet Python ML runtime scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
           python-version: "3.11"
       - name: Validate examples
         run: python src/lattice_forge/validate_runtime_asset.py examples/*.json
+      - name: Validate runtime descriptors
+        run: python src/lattice_forge/validate_runtime_asset.py runtimes/*/runtime-asset.json
       - name: Run tests
         run: |
           python -m pip install --upgrade pip pytest

--- a/runtimes/prophet-python-ml/flake.nix
+++ b/runtimes/prophet-python-ml/flake.nix
@@ -1,0 +1,44 @@
+{
+  description = "Prophet Python ML runtime scaffold for Lattice Forge";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+    in {
+      packages = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in {
+          prophet-python-ml = pkgs.buildEnv {
+            name = "prophet-python-ml-runtime";
+            paths = with pkgs; [
+              python311
+              python311Packages.pip
+              python311Packages.ipykernel
+              python311Packages.numpy
+              python311Packages.pandas
+              python311Packages.pyarrow
+              python311Packages.scikit-learn
+              python311Packages.jupyterlab
+              git
+              jq
+            ];
+          };
+          default = self.packages.${system}.prophet-python-ml;
+        });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in {
+          default = pkgs.mkShell {
+            packages = [ self.packages.${system}.prophet-python-ml ];
+          };
+        });
+    };
+}

--- a/runtimes/prophet-python-ml/runtime-asset.json
+++ b/runtimes/prophet-python-ml/runtime-asset.json
@@ -1,0 +1,51 @@
+{
+  "apiVersion": "lattice.socioprophet.dev/v1",
+  "kind": "RuntimeAsset",
+  "metadata": {
+    "name": "prophet-python-ml",
+    "version": "0.1.0",
+    "createdAt": "2026-04-26T00:00:00Z",
+    "labels": {
+      "runtime": "python-ml",
+      "surface": "lattice-studio"
+    }
+  },
+  "spec": {
+    "runtimeClass": "notebook",
+    "languages": ["python", "shell"],
+    "channels": [
+      {"name": "nixpkgs", "type": "nixpkgs", "trusted": true},
+      {"name": "prophet-core", "type": "prophet", "trusted": true}
+    ],
+    "build": {
+      "system": "nix",
+      "entrypoint": "runtimes/prophet-python-ml/flake.nix",
+      "lockfile": "runtimes/prophet-python-ml/flake.lock",
+      "sourceRef": "local",
+      "builderId": "lattice-forge-nix-builder"
+    },
+    "artifacts": [
+      {"name": "runtime-closure", "role": "nix-closure", "digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777"},
+      {"name": "runtime-sbom", "role": "sbom", "digest": "sha256:8888888888888888888888888888888888888888888888888888888888888888"}
+    ],
+    "provenance": {
+      "attestations": ["slsa", "in-toto"],
+      "sourceRefs": ["local-source-ref"],
+      "builderId": "lattice-forge-nix-builder"
+    },
+    "sbom": {
+      "formats": ["spdx", "cyclonedx"],
+      "digest": "sha256:9999999999999999999999999999999999999999999999999999999999999999"
+    },
+    "signature": {
+      "type": "sigstore",
+      "bundleRef": "pending-demo-bundle",
+      "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "scan": {"vulnerability": "not-run", "license": "not-run", "policy": "not-run"},
+    "policy": {"network": "restricted", "secrets": "scoped", "accelerators": ["cpu"], "defaultIsolation": "container"},
+    "compatibility": {"surfaces": ["jupyter", "ray", "beam", "agentplane", "sourceos-user", "prophet-platform"]},
+    "telemetry": {"traceRequired": true, "metricSet": ["build-duration", "scan-duration", "artifact-size", "promotion-result"]},
+    "promotion": {"channel": "dev", "rollbackRef": "runtime/prophet-python-ml/0.0.1"}
+  }
+}


### PR DESCRIPTION
## Summary

Adds the first concrete runtime scaffold for `prophet-python-ml`.

## What changed

- Adds a Nix flake scaffold under `runtimes/prophet-python-ml/`.
- Adds a v1 RuntimeAsset descriptor for the runtime.
- Extends CI to validate runtime descriptors in addition to examples.

## Why

This starts turning RuntimeAsset v1 from a contract into an executable runtime distribution path for notebooks, Ray/Beam-adjacent work, AgentPlane, and SourceOS user-plane integration.

## Next

- Add generated lockfile/provenance placeholder policy.
- Add SBOM generation stub.
- Add Jupyter kernel spec packaging.
- Add Ray and Beam runtime profiles.
