### PR TITLE
Add runtime evidence and Jupyter kernel sidecars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         run: python src/lattice_forge/validate_runtime_asset.py examples/*.json
       - name: Validate runtime descriptors
         run: python src/lattice_forge/validate_runtime_asset.py runtimes/*/runtime-asset.json
+      - name: Validate runtime evidence sidecars
+        run: python src/lattice_forge/validate_runtime_evidence.py runtimes/*
       - name: Run tests
         run: |
           python -m pip install --upgrade pip pytest

--- a/runtimes/prophet-python-ml/evidence/provenance.intoto.json
+++ b/runtimes/prophet-python-ml/evidence/provenance.intoto.json
@@ -1,0 +1,32 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "prophet-python-ml",
+      "digest": {
+        "sha256": "7777777777777777777777777777777777777777777777777777777777777777"
+      }
+    }
+  ],
+  "predicateType": "https://slsa.dev/provenance/v1",
+  "predicate": {
+    "buildDefinition": {
+      "buildType": "https://socioprophet.dev/lattice-forge/nix-runtime/v1",
+      "externalParameters": {
+        "entrypoint": "runtimes/prophet-python-ml/flake.nix",
+        "runtimeAsset": "runtimes/prophet-python-ml/runtime-asset.json"
+      },
+      "internalParameters": {}
+    },
+    "runDetails": {
+      "builder": {
+        "id": "lattice-forge-nix-builder"
+      },
+      "metadata": {
+        "invocationId": "placeholder-local-demo",
+        "startedOn": "2026-04-26T00:00:00Z",
+        "finishedOn": "2026-04-26T00:00:00Z"
+      }
+    }
+  }
+}

--- a/runtimes/prophet-python-ml/evidence/sbom.spdx.json
+++ b/runtimes/prophet-python-ml/evidence/sbom.spdx.json
@@ -1,0 +1,29 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "prophet-python-ml-runtime-sbom-placeholder",
+  "documentNamespace": "https://example.invalid/spdx/prophet-python-ml/0.1.0",
+  "creationInfo": {
+    "created": "2026-04-26T00:00:00Z",
+    "creators": ["Organization: SocioProphet", "Tool: lattice-forge-placeholder"]
+  },
+  "packages": [
+    {
+      "name": "prophet-python-ml",
+      "SPDXID": "SPDXRef-Package-prophet-python-ml",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION"
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-prophet-python-ml"
+    }
+  ]
+}

--- a/runtimes/prophet-python-ml/evidence/scan.summary.json
+++ b/runtimes/prophet-python-ml/evidence/scan.summary.json
@@ -1,0 +1,13 @@
+{
+  "runtimeAsset": "prophet-python-ml@0.1.0",
+  "generatedAt": "2026-04-26T00:00:00Z",
+  "status": {
+    "vulnerability": "not-run",
+    "license": "not-run",
+    "policy": "not-run"
+  },
+  "notes": [
+    "Placeholder scan summary. Real scanner integration must replace this before stable promotion.",
+    "RuntimeAsset promotion channel remains dev until scan evidence is produced."
+  ]
+}

--- a/runtimes/prophet-python-ml/kernel/kernel.json
+++ b/runtimes/prophet-python-ml/kernel/kernel.json
@@ -1,0 +1,19 @@
+{
+  "argv": [
+    "python",
+    "-m",
+    "ipykernel_launcher",
+    "-f",
+    "{connection_file}"
+  ],
+  "display_name": "Prophet Python ML",
+  "language": "python",
+  "metadata": {
+    "runtimeAsset": "prophet-python-ml@0.1.0",
+    "governance": {
+      "evidenceRequired": true,
+      "policyProfile": "dev",
+      "defaultIsolation": "container"
+    }
+  }
+}

--- a/src/lattice_forge/validate_runtime_evidence.py
+++ b/src/lattice_forge/validate_runtime_evidence.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Validate runtime evidence sidecar files.
+
+This is a lightweight CI gate for the first evidence tranche. It does not claim
+full SPDX, SLSA, or in-toto conformance; it verifies that the expected evidence
+files exist and contain the required top-level fields before we wire dedicated
+validators.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REQUIRED_FILES = {
+    "kernel/kernel.json": ["argv", "display_name", "language", "metadata"],
+    "evidence/sbom.spdx.json": ["spdxVersion", "SPDXID", "name", "creationInfo", "packages"],
+    "evidence/provenance.intoto.json": ["_type", "subject", "predicateType", "predicate"],
+    "evidence/scan.summary.json": ["runtimeAsset", "generatedAt", "status"],
+}
+
+
+def validate_runtime_dir(runtime_dir: Path) -> None:
+    for rel_path, required_keys in REQUIRED_FILES.items():
+        path = runtime_dir / rel_path
+        if not path.exists():
+            raise ValueError(f"missing required runtime evidence file: {path}")
+        doc = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(doc, dict):
+            raise ValueError(f"expected JSON object in {path}")
+        missing = [key for key in required_keys if key not in doc]
+        if missing:
+            raise ValueError(f"{path} missing required keys: {', '.join(missing)}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate runtime evidence sidecars")
+    parser.add_argument("runtime_dirs", nargs="+", type=Path)
+    args = parser.parse_args(argv)
+
+    failed = False
+    for runtime_dir in args.runtime_dirs:
+        try:
+            validate_runtime_dir(runtime_dir)
+            print(f"PASS {runtime_dir}")
+        except Exception as exc:  # noqa: BLE001
+            failed = True
+            print(f"FAIL {runtime_dir}: {exc}", file=sys.stderr)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds governed evidence sidecars and Jupyter kernel metadata for the first `prophet-python-ml` runtime.

## What changed

- Adds Jupyter kernel spec with runtime governance metadata.
- Adds SPDX SBOM placeholder.
- Adds in-toto/SLSA-style provenance placeholder.
- Adds scan summary placeholder.
- Adds `validate_runtime_evidence.py`.
- Extends CI to validate runtime evidence sidecars.

## Why

RuntimeAsset v1 requires more than package metadata. This PR starts the evidence lane needed for world-class runtime promotion: kernel metadata, SBOM, provenance, and scan posture.

## Notes

The SBOM/provenance/scan files are placeholders by design. They establish file shape and CI gating before scanner/build integrations replace their contents with generated evidence.
