### PR TITLE
Add runtime evidence summary CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
         run: python src/lattice_forge/validate_runtime_asset.py runtimes/*/runtime-asset.json
       - name: Validate runtime evidence sidecars
         run: python src/lattice_forge/validate_runtime_evidence.py runtimes/*
+      - name: Generate runtime evidence summary
+        run: python src/lattice_forge/evidence_summary.py runtimes/prophet-python-ml
       - name: Run tests
         run: |
           python -m pip install --upgrade pip pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 description = "Governed Nix/conda-compatible runtimes, package channels, kernels, images, SBOMs, and signed runtime releases."
 requires-python = ">=3.11"
 
+[project.scripts]
+lattice-forge-evidence-summary = "lattice_forge.evidence_summary:main"
+
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 testpaths = ["tests"]

--- a/src/lattice_forge/evidence_summary.py
+++ b/src/lattice_forge/evidence_summary.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Generate a compact runtime evidence summary.
+
+This tool is intentionally side-effect-free. It reads a RuntimeAsset descriptor
+and expected evidence sidecars, then emits a single JSON summary suitable for
+Prophet Platform ingestion or premerge inspection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+EVIDENCE_PATHS = {
+    "kernel": "kernel/kernel.json",
+    "sbom": "evidence/sbom.spdx.json",
+    "provenance": "evidence/provenance.intoto.json",
+    "scan": "evidence/scan.summary.json",
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return data
+
+
+def summarize(runtime_dir: Path) -> dict[str, Any]:
+    runtime_asset_path = runtime_dir / "runtime-asset.json"
+    runtime_asset = load_json(runtime_asset_path)
+    metadata = runtime_asset.get("metadata", {})
+    spec = runtime_asset.get("spec", {})
+
+    evidence = {}
+    for name, rel_path in EVIDENCE_PATHS.items():
+        path = runtime_dir / rel_path
+        doc = load_json(path)
+        evidence[name] = {
+            "path": rel_path,
+            "present": True,
+            "topLevelKeys": sorted(doc.keys()),
+        }
+
+    return {
+        "apiVersion": "lattice.socioprophet.dev/v1",
+        "kind": "RuntimeEvidenceSummary",
+        "runtime": {
+            "name": metadata.get("name"),
+            "version": metadata.get("version"),
+            "runtimeClass": spec.get("runtimeClass"),
+            "languages": spec.get("languages", []),
+            "promotion": spec.get("promotion", {}),
+        },
+        "policy": spec.get("policy", {}),
+        "compatibility": spec.get("compatibility", {}),
+        "evidence": evidence,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate RuntimeEvidenceSummary JSON")
+    parser.add_argument("runtime_dir", type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        print(json.dumps(summarize(args.runtime_dir), indent=2, sort_keys=True))
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        print(f"lattice-forge-evidence-summary: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_evidence_summary.py
+++ b/tests/test_evidence_summary.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+from lattice_forge.evidence_summary import main, summarize
+
+
+def test_evidence_summary_for_prophet_python_ml() -> None:
+    root = Path(__file__).resolve().parents[1]
+    runtime_dir = root / "runtimes" / "prophet-python-ml"
+    summary = summarize(runtime_dir)
+
+    assert summary["kind"] == "RuntimeEvidenceSummary"
+    assert summary["runtime"]["name"] == "prophet-python-ml"
+    assert summary["evidence"]["kernel"]["present"] is True
+    assert summary["evidence"]["sbom"]["present"] is True
+    assert summary["evidence"]["provenance"]["present"] is True
+    assert summary["evidence"]["scan"]["present"] is True
+
+
+def test_evidence_summary_cli(capsys) -> None:
+    root = Path(__file__).resolve().parents[1]
+    runtime_dir = root / "runtimes" / "prophet-python-ml"
+    assert main([str(runtime_dir)]) == 0
+    emitted = json.loads(capsys.readouterr().out)
+    assert emitted["kind"] == "RuntimeEvidenceSummary"


### PR DESCRIPTION
## Summary

Adds a side-effect-free CLI that summarizes RuntimeAsset evidence sidecars for platform ingestion and inspection.

## What changed

- Adds `lattice_forge.evidence_summary`.
- Exposes `lattice-forge-evidence-summary` project script.
- Adds tests for summary generation and CLI output.
- Extends CI to generate a summary for `runtimes/prophet-python-ml`.

## Why

Runtime evidence should not remain a set of loose files. This gives Prophet Platform and premerge validation a compact, deterministic view of runtime metadata, evidence sidecars, policy, compatibility, and promotion state.

## Safety

The tool is read-only and side-effect-free.
