### PR TITLE
Emit first RuntimeAsset build artifact

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
-.PHONY: validate runtime-candidates-validate
+.PHONY: validate runtime-candidates-validate runtime-asset-emit runtime-asset-validate
 
-validate: runtime-candidates-validate
+validate: runtime-candidates-validate runtime-asset-validate
 	@echo "OK: validate"
 
 runtime-candidates-validate:
 	./.venv/bin/python tools/validate_runtime_candidates.py 2>/dev/null || python3 tools/validate_runtime_candidates.py
+
+runtime-asset-emit:
+	./.venv/bin/python tools/emit_runtime_asset.py 2>/dev/null || python3 tools/emit_runtime_asset.py
+
+runtime-asset-validate: runtime-asset-emit
+	./.venv/bin/python src/lattice_forge/validate_runtime_asset.py examples/runtime-asset.example.json build/runtime-assets/prophet-python-ml.runtime-asset.json 2>/dev/null || python3 src/lattice_forge/validate_runtime_asset.py examples/runtime-asset.example.json build/runtime-assets/prophet-python-ml.runtime-asset.json

--- a/runtimes/prophet-python-ml/conda-lock.yml
+++ b/runtimes/prophet-python-ml/conda-lock.yml
@@ -1,0 +1,17 @@
+# Conda-compatible lock placeholder for prophet-python-ml.
+# This file intentionally uses open channels and is hashable by the RuntimeAsset emitter.
+channels:
+  - conda-forge
+platforms:
+  - linux-64
+  - linux-aarch64
+  - osx-arm64
+packages:
+  - python=3.11
+  - ipykernel
+  - numpy
+  - pandas
+  - pyarrow
+  - scikit-learn
+  - jupyterlab
+  - duckdb

--- a/runtimes/prophet-python-ml/kernel.json
+++ b/runtimes/prophet-python-ml/kernel.json
@@ -1,0 +1,16 @@
+{
+  "argv": [
+    "python",
+    "-m",
+    "ipykernel_launcher",
+    "-f",
+    "{connection_file}"
+  ],
+  "display_name": "Prophet Python ML 0.1.0",
+  "language": "python",
+  "metadata": {
+    "runtimeAssetId": "runtime-asset:prophet-python-ml:0.1.0",
+    "policyRef": "policy://runtime/prophet-python-ml-demo",
+    "surfaces": ["jupyter", "jupyterlab", "lattice-studio"]
+  }
+}

--- a/tools/emit_runtime_asset.py
+++ b/tools/emit_runtime_asset.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_DIR = ROOT / "runtimes" / "prophet-python-ml"
+BUILD_DIR = ROOT / "build" / "runtime-assets"
+
+
+def digest_file(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def artifact(path: Path, role: str, media_type: str) -> dict:
+    rel = path.relative_to(ROOT).as_posix()
+    return {
+        "name": rel,
+        "role": role,
+        "digest": digest_file(path),
+        "uri": rel,
+        "mediaType": media_type,
+    }
+
+
+def runtime_asset() -> dict:
+    flake = RUNTIME_DIR / "flake.nix"
+    lock = RUNTIME_DIR / "conda-lock.yml"
+    kernel = RUNTIME_DIR / "kernel.json"
+    artifacts = [
+        artifact(flake, "nix-closure", "text/x-nix"),
+        artifact(lock, "lockfile", "application/x-yaml"),
+        artifact(kernel, "kernel-spec", "application/json"),
+    ]
+    sbom_digest = "sha256:" + hashlib.sha256(json.dumps(artifacts, sort_keys=True).encode("utf-8")).hexdigest()
+    return {
+        "apiVersion": "lattice.socioprophet.dev/v1",
+        "kind": "RuntimeAsset",
+        "metadata": {
+            "name": "prophet-python-ml",
+            "version": "0.1.0",
+            "createdAt": "2026-05-01T19:00:00Z",
+            "labels": {"lane": "lattice-studio-data-governai"},
+        },
+        "spec": {
+            "runtimeClass": "notebook",
+            "languages": ["python", "sql"],
+            "channels": [
+                {"name": "nixpkgs", "type": "nixpkgs", "trusted": True},
+                {"name": "conda-forge", "type": "conda-forge", "trusted": True},
+                {"name": "prophet-core", "type": "prophet", "trusted": True},
+            ],
+            "build": {
+                "system": "mixed",
+                "entrypoint": "runtimes/prophet-python-ml/flake.nix",
+                "lockfile": "runtimes/prophet-python-ml/conda-lock.yml",
+                "sourceRef": "SocioProphet/lattice-forge",
+                "builderId": "lattice-forge-demo-builder",
+            },
+            "artifacts": artifacts,
+            "provenance": {
+                "attestations": ["slsa", "in-toto"],
+                "sourceRefs": ["SocioProphet/lattice-forge"],
+                "builderId": "lattice-forge-demo-builder",
+            },
+            "sbom": {"formats": ["spdx"], "digest": sbom_digest, "uri": "build/runtime-assets/prophet-python-ml.sbom.spdx.json"},
+            "signature": {"type": "sigstore", "bundleRef": "build/runtime-assets/prophet-python-ml.sigstore.bundle", "digest": sbom_digest},
+            "scan": {"vulnerability": "not-run", "license": "not-run", "policy": "not-run"},
+            "policy": {"network": "restricted", "secrets": "scoped", "accelerators": ["cpu"], "defaultIsolation": "container"},
+            "compatibility": {
+                "surfaces": ["jupyter", "jupyterlab", "lattice-studio", "ray", "beam", "agentplane", "sourceos-user", "prophet-platform"]
+            },
+            "telemetry": {"traceRequired": True, "metricSet": ["build-duration", "scan-duration", "artifact-size", "promotion-result"]},
+            "promotion": {"channel": "dev", "rollbackRef": "runtime/prophet-python-ml/0.0.1"},
+        },
+    }
+
+
+def main() -> int:
+    BUILD_DIR.mkdir(parents=True, exist_ok=True)
+    output = BUILD_DIR / "prophet-python-ml.runtime-asset.json"
+    output.write_text(json.dumps(runtime_asset(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"written": [str(output)]}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the first deterministic RuntimeAsset build artifact path for Lattice Forge.

## Adds

- conda-compatible lock placeholder for `prophet-python-ml`
- Jupyter kernel metadata for `prophet-python-ml`
- deterministic RuntimeAsset emitter
- Makefile validation wiring for generated RuntimeAsset output

## Validation

Expected:

```bash
make validate
```

## Tracking

Advances #9.
Coordinates with SocioProphet/prophet-platform#291 and SocioProphet/prophet-platform#292.