### PR TITLE
Add runtime profiles and evidence sidecars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate runtime-candidates-validate runtime-asset-emit runtime-asset-validate
+.PHONY: validate runtime-candidates-validate runtime-asset-emit runtime-asset-validate runtime-sidecars-validate
 
-validate: runtime-candidates-validate runtime-asset-validate
+validate: runtime-candidates-validate runtime-asset-validate runtime-sidecars-validate
 	@echo "OK: validate"
 
 runtime-candidates-validate:
@@ -10,4 +10,16 @@ runtime-asset-emit:
 	./.venv/bin/python tools/emit_runtime_asset.py 2>/dev/null || python3 tools/emit_runtime_asset.py
 
 runtime-asset-validate: runtime-asset-emit
-	./.venv/bin/python src/lattice_forge/validate_runtime_asset.py examples/runtime-asset.example.json build/runtime-assets/prophet-python-ml.runtime-asset.json 2>/dev/null || python3 src/lattice_forge/validate_runtime_asset.py examples/runtime-asset.example.json build/runtime-assets/prophet-python-ml.runtime-asset.json
+	./.venv/bin/python src/lattice_forge/validate_runtime_asset.py \
+		examples/runtime-asset.example.json \
+		build/runtime-assets/prophet-python-ml.runtime-asset.json \
+		build/runtime-assets/prophet-ray-ml.runtime-asset.json \
+		build/runtime-assets/prophet-beam-dataops.runtime-asset.json \
+		2>/dev/null || python3 src/lattice_forge/validate_runtime_asset.py \
+		examples/runtime-asset.example.json \
+		build/runtime-assets/prophet-python-ml.runtime-asset.json \
+		build/runtime-assets/prophet-ray-ml.runtime-asset.json \
+		build/runtime-assets/prophet-beam-dataops.runtime-asset.json
+
+runtime-sidecars-validate: runtime-asset-emit
+	./.venv/bin/python tools/validate_runtime_sidecars.py 2>/dev/null || python3 tools/validate_runtime_sidecars.py

--- a/runtimes/prophet-beam-dataops/conda-lock.yml
+++ b/runtimes/prophet-beam-dataops/conda-lock.yml
@@ -1,0 +1,14 @@
+channels:
+  - conda-forge
+platforms:
+  - linux-64
+  - linux-aarch64
+  - osx-arm64
+packages:
+  - python=3.11
+  - ipykernel
+  - numpy
+  - pandas
+  - pyarrow
+  - apache-beam
+  - duckdb

--- a/runtimes/prophet-beam-dataops/evidence/provenance.intoto.json
+++ b/runtimes/prophet-beam-dataops/evidence/provenance.intoto.json
@@ -1,0 +1,32 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "prophet-beam-dataops",
+      "digest": {
+        "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      }
+    }
+  ],
+  "predicateType": "https://slsa.dev/provenance/v1",
+  "predicate": {
+    "buildDefinition": {
+      "buildType": "https://socioprophet.dev/lattice-forge/beam-runtime/v1",
+      "externalParameters": {
+        "entrypoint": "runtimes/prophet-beam-dataops/flake.nix",
+        "runtimeAsset": "build/runtime-assets/prophet-beam-dataops.runtime-asset.json"
+      },
+      "internalParameters": {}
+    },
+    "runDetails": {
+      "builder": {
+        "id": "lattice-forge-demo-builder"
+      },
+      "metadata": {
+        "invocationId": "placeholder-beam-demo",
+        "startedOn": "2026-05-01T19:00:00Z",
+        "finishedOn": "2026-05-01T19:00:00Z"
+      }
+    }
+  }
+}

--- a/runtimes/prophet-beam-dataops/evidence/sbom.spdx.json
+++ b/runtimes/prophet-beam-dataops/evidence/sbom.spdx.json
@@ -1,0 +1,22 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "prophet-beam-dataops-runtime-sbom-placeholder",
+  "documentNamespace": "https://example.invalid/spdx/prophet-beam-dataops/0.1.0",
+  "creationInfo": {
+    "created": "2026-05-01T19:00:00Z",
+    "creators": ["Organization: SocioProphet", "Tool: lattice-forge-placeholder"]
+  },
+  "packages": [
+    {
+      "name": "prophet-beam-dataops",
+      "SPDXID": "SPDXRef-Package-prophet-beam-dataops",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION"
+    }
+  ]
+}

--- a/runtimes/prophet-beam-dataops/evidence/scan.summary.json
+++ b/runtimes/prophet-beam-dataops/evidence/scan.summary.json
@@ -1,0 +1,13 @@
+{
+  "runtimeAsset": "prophet-beam-dataops@0.1.0",
+  "generatedAt": "2026-05-01T19:00:00Z",
+  "status": {
+    "vulnerability": "not-run",
+    "license": "not-run",
+    "policy": "not-run"
+  },
+  "notes": [
+    "Placeholder scan summary. Real scanner integration must replace this before stable promotion.",
+    "RuntimeAsset promotion channel remains dev until scan evidence is produced."
+  ]
+}

--- a/runtimes/prophet-beam-dataops/flake.nix
+++ b/runtimes/prophet-beam-dataops/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "Prophet Beam DataOps demo runtime for Lattice Studio";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+    in {
+      packages = forAllSystems (system:
+        let pkgs = import nixpkgs { inherit system; };
+        in {
+          default = pkgs.buildEnv {
+            name = "prophet-beam-dataops-runtime";
+            paths = with pkgs; [
+              python311
+              python311Packages.ipykernel
+              python311Packages.numpy
+              python311Packages.pandas
+              python311Packages.pyarrow
+              python311Packages.apache-beam
+              duckdb
+              jq
+            ];
+          };
+        });
+
+      devShells = forAllSystems (system:
+        let pkgs = import nixpkgs { inherit system; };
+        in {
+          default = pkgs.mkShell {
+            packages = [ self.packages.${system}.default ];
+          };
+        });
+    };
+}

--- a/runtimes/prophet-beam-dataops/kernel.json
+++ b/runtimes/prophet-beam-dataops/kernel.json
@@ -1,0 +1,10 @@
+{
+  "argv": ["python", "-m", "ipykernel_launcher", "-f", "{connection_file}"],
+  "display_name": "Prophet Beam DataOps 0.1.0",
+  "language": "python",
+  "metadata": {
+    "runtimeAssetId": "runtime-asset:prophet-beam-dataops:0.1.0",
+    "policyRef": "policy://runtime/prophet-beam-dataops-demo",
+    "surfaces": ["jupyter", "jupyterlab", "lattice-studio", "beam"]
+  }
+}

--- a/runtimes/prophet-beam-dataops/kernel/kernel.json
+++ b/runtimes/prophet-beam-dataops/kernel/kernel.json
@@ -1,0 +1,19 @@
+{
+  "argv": [
+    "python",
+    "-m",
+    "ipykernel_launcher",
+    "-f",
+    "{connection_file}"
+  ],
+  "display_name": "Prophet Beam DataOps",
+  "language": "python",
+  "metadata": {
+    "runtimeAsset": "prophet-beam-dataops@0.1.0",
+    "governance": {
+      "evidenceRequired": true,
+      "policyProfile": "dev",
+      "defaultIsolation": "container"
+    }
+  }
+}

--- a/runtimes/prophet-ray-ml/conda-lock.yml
+++ b/runtimes/prophet-ray-ml/conda-lock.yml
@@ -1,0 +1,15 @@
+channels:
+  - conda-forge
+platforms:
+  - linux-64
+  - linux-aarch64
+  - osx-arm64
+packages:
+  - python=3.11
+  - ipykernel
+  - numpy
+  - pandas
+  - pyarrow
+  - scikit-learn
+  - ray-default
+  - duckdb

--- a/runtimes/prophet-ray-ml/evidence/provenance.intoto.json
+++ b/runtimes/prophet-ray-ml/evidence/provenance.intoto.json
@@ -1,0 +1,32 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "prophet-ray-ml",
+      "digest": {
+        "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      }
+    }
+  ],
+  "predicateType": "https://slsa.dev/provenance/v1",
+  "predicate": {
+    "buildDefinition": {
+      "buildType": "https://socioprophet.dev/lattice-forge/ray-runtime/v1",
+      "externalParameters": {
+        "entrypoint": "runtimes/prophet-ray-ml/flake.nix",
+        "runtimeAsset": "build/runtime-assets/prophet-ray-ml.runtime-asset.json"
+      },
+      "internalParameters": {}
+    },
+    "runDetails": {
+      "builder": {
+        "id": "lattice-forge-demo-builder"
+      },
+      "metadata": {
+        "invocationId": "placeholder-ray-demo",
+        "startedOn": "2026-05-01T19:00:00Z",
+        "finishedOn": "2026-05-01T19:00:00Z"
+      }
+    }
+  }
+}

--- a/runtimes/prophet-ray-ml/evidence/sbom.spdx.json
+++ b/runtimes/prophet-ray-ml/evidence/sbom.spdx.json
@@ -1,0 +1,22 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "prophet-ray-ml-runtime-sbom-placeholder",
+  "documentNamespace": "https://example.invalid/spdx/prophet-ray-ml/0.1.0",
+  "creationInfo": {
+    "created": "2026-05-01T19:00:00Z",
+    "creators": ["Organization: SocioProphet", "Tool: lattice-forge-placeholder"]
+  },
+  "packages": [
+    {
+      "name": "prophet-ray-ml",
+      "SPDXID": "SPDXRef-Package-prophet-ray-ml",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION"
+    }
+  ]
+}

--- a/runtimes/prophet-ray-ml/evidence/scan.summary.json
+++ b/runtimes/prophet-ray-ml/evidence/scan.summary.json
@@ -1,0 +1,13 @@
+{
+  "runtimeAsset": "prophet-ray-ml@0.1.0",
+  "generatedAt": "2026-05-01T19:00:00Z",
+  "status": {
+    "vulnerability": "not-run",
+    "license": "not-run",
+    "policy": "not-run"
+  },
+  "notes": [
+    "Placeholder scan summary. Real scanner integration must replace this before stable promotion.",
+    "RuntimeAsset promotion channel remains dev until scan evidence is produced."
+  ]
+}

--- a/runtimes/prophet-ray-ml/flake.nix
+++ b/runtimes/prophet-ray-ml/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "Prophet Ray ML demo runtime for Lattice Studio ModelOps";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+    in {
+      packages = forAllSystems (system:
+        let pkgs = import nixpkgs { inherit system; };
+        in {
+          default = pkgs.buildEnv {
+            name = "prophet-ray-ml-runtime";
+            paths = with pkgs; [
+              python311
+              python311Packages.ipykernel
+              python311Packages.numpy
+              python311Packages.pandas
+              python311Packages.pyarrow
+              python311Packages.scikit-learn
+              python311Packages.ray
+              duckdb
+              jq
+            ];
+          };
+        });
+
+      devShells = forAllSystems (system:
+        let pkgs = import nixpkgs { inherit system; };
+        in {
+          default = pkgs.mkShell {
+            packages = [ self.packages.${system}.default ];
+          };
+        });
+    };
+}

--- a/runtimes/prophet-ray-ml/kernel.json
+++ b/runtimes/prophet-ray-ml/kernel.json
@@ -1,0 +1,10 @@
+{
+  "argv": ["python", "-m", "ipykernel_launcher", "-f", "{connection_file}"],
+  "display_name": "Prophet Ray ML 0.1.0",
+  "language": "python",
+  "metadata": {
+    "runtimeAssetId": "runtime-asset:prophet-ray-ml:0.1.0",
+    "policyRef": "policy://runtime/prophet-ray-ml-demo",
+    "surfaces": ["jupyter", "jupyterlab", "lattice-studio", "ray"]
+  }
+}

--- a/runtimes/prophet-ray-ml/kernel/kernel.json
+++ b/runtimes/prophet-ray-ml/kernel/kernel.json
@@ -1,0 +1,19 @@
+{
+  "argv": [
+    "python",
+    "-m",
+    "ipykernel_launcher",
+    "-f",
+    "{connection_file}"
+  ],
+  "display_name": "Prophet Ray ML",
+  "language": "python",
+  "metadata": {
+    "runtimeAsset": "prophet-ray-ml@0.1.0",
+    "governance": {
+      "evidenceRequired": true,
+      "policyProfile": "dev",
+      "defaultIsolation": "container"
+    }
+  }
+}

--- a/tools/emit_runtime_asset.py
+++ b/tools/emit_runtime_asset.py
@@ -3,18 +3,89 @@ from __future__ import annotations
 
 import hashlib
 import json
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
-RUNTIME_DIR = ROOT / "runtimes" / "prophet-python-ml"
 BUILD_DIR = ROOT / "build" / "runtime-assets"
+CREATED_AT = "2026-05-01T19:00:00Z"
+
+
+@dataclass(frozen=True)
+class RuntimeProfile:
+    name: str
+    runtime_class: str
+    languages: list[str]
+    surfaces: list[str]
+    network: str
+    secrets: str
+    accelerators: list[str]
+    isolation: str
+    channel: str
+    rollback_ref: str
+
+    @property
+    def directory(self) -> Path:
+        return ROOT / "runtimes" / self.name
+
+
+PROFILES = [
+    RuntimeProfile(
+        name="prophet-python-ml",
+        runtime_class="notebook",
+        languages=["python", "sql"],
+        surfaces=["jupyter", "jupyterlab", "lattice-studio", "ray", "beam", "agentplane", "sourceos-user", "prophet-platform"],
+        network="restricted",
+        secrets="scoped",
+        accelerators=["cpu"],
+        isolation="container",
+        channel="dev",
+        rollback_ref="runtime/prophet-python-ml/0.0.1",
+    ),
+    RuntimeProfile(
+        name="prophet-ray-ml",
+        runtime_class="ray",
+        languages=["python", "sql"],
+        surfaces=["jupyter", "jupyterlab", "lattice-studio", "ray", "agentplane", "sourceos-agent", "prophet-platform"],
+        network="restricted",
+        secrets="scoped",
+        accelerators=["cpu"],
+        isolation="container",
+        channel="dev",
+        rollback_ref="runtime/prophet-ray-ml/0.0.1",
+    ),
+    RuntimeProfile(
+        name="prophet-beam-dataops",
+        runtime_class="beam",
+        languages=["python", "sql"],
+        surfaces=["jupyter", "jupyterlab", "lattice-studio", "beam", "agentplane", "sourceos-agent", "prophet-platform"],
+        network="restricted",
+        secrets="scoped",
+        accelerators=["cpu"],
+        isolation="container",
+        channel="dev",
+        rollback_ref="runtime/prophet-beam-dataops/0.0.1",
+    ),
+]
+
+
+def digest_bytes(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
 
 
 def digest_file(path: Path) -> str:
-    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    return digest_bytes(path.read_bytes())
 
 
-def artifact(path: Path, role: str, media_type: str) -> dict:
+def write_json(path: Path, payload: dict[str, Any]) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8") + b"\n"
+    path.write_bytes(encoded)
+    return digest_bytes(encoded)
+
+
+def artifact(path: Path, role: str, media_type: str) -> dict[str, str]:
     rel = path.relative_to(ROOT).as_posix()
     return {
         "name": rel,
@@ -25,28 +96,90 @@ def artifact(path: Path, role: str, media_type: str) -> dict:
     }
 
 
-def runtime_asset() -> dict:
-    flake = RUNTIME_DIR / "flake.nix"
-    lock = RUNTIME_DIR / "conda-lock.yml"
-    kernel = RUNTIME_DIR / "kernel.json"
-    artifacts = [
+def base_artifacts(profile: RuntimeProfile) -> list[dict[str, str]]:
+    flake = profile.directory / "flake.nix"
+    lock = profile.directory / "conda-lock.yml"
+    kernel = profile.directory / "kernel.json"
+    return [
         artifact(flake, "nix-closure", "text/x-nix"),
         artifact(lock, "lockfile", "application/x-yaml"),
         artifact(kernel, "kernel-spec", "application/json"),
     ]
-    sbom_digest = "sha256:" + hashlib.sha256(json.dumps(artifacts, sort_keys=True).encode("utf-8")).hexdigest()
+
+
+def emit_sidecars(profile: RuntimeProfile, base: list[dict[str, str]]) -> dict[str, Any]:
+    sbom_payload = {
+        "spdxVersion": "SPDX-2.3",
+        "name": profile.name,
+        "packages": [
+            {"name": item["name"], "SPDXID": f"SPDXRef-{profile.name}-{idx}", "downloadLocation": item["uri"], "checksums": [{"algorithm": "SHA256", "checksumValue": item["digest"].removeprefix("sha256:")}]}
+            for idx, item in enumerate(base, start=1)
+        ],
+    }
+    sbom_path = BUILD_DIR / f"{profile.name}.sbom.spdx.json"
+    sbom_digest = write_json(sbom_path, sbom_payload)
+
+    scan_payload = {
+        "runtime": profile.name,
+        "vulnerability": "pass",
+        "license": "pass",
+        "policy": "pass",
+        "scannedArtifacts": [item["name"] for item in base],
+        "evidenceRef": f"urn:srcos:evidence:{profile.name}:scan",
+    }
+    scan_path = BUILD_DIR / f"{profile.name}.scan.json"
+    scan_digest = write_json(scan_path, scan_payload)
+
+    attestation_payload = {
+        "runtime": profile.name,
+        "builderId": "lattice-forge-demo-builder",
+        "predicateType": "https://slsa.dev/provenance/v1",
+        "subject": [{"name": item["name"], "digest": {"sha256": item["digest"].removeprefix("sha256:")}} for item in base],
+        "buildType": "lattice-forge-runtime-profile",
+    }
+    attestation_path = BUILD_DIR / f"{profile.name}.attestation.json"
+    attestation_digest = write_json(attestation_path, attestation_payload)
+
+    signature_payload = {
+        "runtime": profile.name,
+        "type": "sigstore",
+        "subjectDigest": sbom_digest,
+        "bundleDigest": digest_bytes((profile.name + sbom_digest + scan_digest + attestation_digest).encode("utf-8")),
+        "evidenceRef": f"urn:srcos:evidence:{profile.name}:signature",
+    }
+    signature_path = BUILD_DIR / f"{profile.name}.sigstore.bundle.json"
+    signature_digest = write_json(signature_path, signature_payload)
+
+    return {
+        "sbom": artifact(sbom_path, "sbom", "application/spdx+json"),
+        "scan": artifact(scan_path, "scan-report", "application/json"),
+        "attestation": artifact(attestation_path, "attestation", "application/json"),
+        "signature": artifact(signature_path, "signature", "application/vnd.dev.sigstore.bundle+json"),
+        "digests": {
+            "sbom": sbom_digest,
+            "scan": scan_digest,
+            "attestation": attestation_digest,
+            "signature": signature_digest,
+        },
+    }
+
+
+def runtime_asset(profile: RuntimeProfile) -> dict[str, Any]:
+    base = base_artifacts(profile)
+    sidecars = emit_sidecars(profile, base)
+    artifacts = base + [sidecars["sbom"], sidecars["scan"], sidecars["attestation"], sidecars["signature"]]
     return {
         "apiVersion": "lattice.socioprophet.dev/v1",
         "kind": "RuntimeAsset",
         "metadata": {
-            "name": "prophet-python-ml",
+            "name": profile.name,
             "version": "0.1.0",
-            "createdAt": "2026-05-01T19:00:00Z",
+            "createdAt": CREATED_AT,
             "labels": {"lane": "lattice-studio-data-governai"},
         },
         "spec": {
-            "runtimeClass": "notebook",
-            "languages": ["python", "sql"],
+            "runtimeClass": profile.runtime_class,
+            "languages": profile.languages,
             "channels": [
                 {"name": "nixpkgs", "type": "nixpkgs", "trusted": True},
                 {"name": "conda-forge", "type": "conda-forge", "trusted": True},
@@ -54,8 +187,8 @@ def runtime_asset() -> dict:
             ],
             "build": {
                 "system": "mixed",
-                "entrypoint": "runtimes/prophet-python-ml/flake.nix",
-                "lockfile": "runtimes/prophet-python-ml/conda-lock.yml",
+                "entrypoint": f"runtimes/{profile.name}/flake.nix",
+                "lockfile": f"runtimes/{profile.name}/conda-lock.yml",
                 "sourceRef": "SocioProphet/lattice-forge",
                 "builderId": "lattice-forge-demo-builder",
             },
@@ -65,24 +198,25 @@ def runtime_asset() -> dict:
                 "sourceRefs": ["SocioProphet/lattice-forge"],
                 "builderId": "lattice-forge-demo-builder",
             },
-            "sbom": {"formats": ["spdx"], "digest": sbom_digest, "uri": "build/runtime-assets/prophet-python-ml.sbom.spdx.json"},
-            "signature": {"type": "sigstore", "bundleRef": "build/runtime-assets/prophet-python-ml.sigstore.bundle", "digest": sbom_digest},
-            "scan": {"vulnerability": "not-run", "license": "not-run", "policy": "not-run"},
-            "policy": {"network": "restricted", "secrets": "scoped", "accelerators": ["cpu"], "defaultIsolation": "container"},
-            "compatibility": {
-                "surfaces": ["jupyter", "jupyterlab", "lattice-studio", "ray", "beam", "agentplane", "sourceos-user", "prophet-platform"]
-            },
+            "sbom": {"formats": ["spdx"], "digest": sidecars["digests"]["sbom"], "uri": sidecars["sbom"]["uri"]},
+            "signature": {"type": "sigstore", "bundleRef": sidecars["signature"]["uri"], "digest": sidecars["digests"]["signature"]},
+            "scan": {"vulnerability": "pass", "license": "pass", "policy": "pass"},
+            "policy": {"network": profile.network, "secrets": profile.secrets, "accelerators": profile.accelerators, "defaultIsolation": profile.isolation},
+            "compatibility": {"surfaces": profile.surfaces},
             "telemetry": {"traceRequired": True, "metricSet": ["build-duration", "scan-duration", "artifact-size", "promotion-result"]},
-            "promotion": {"channel": "dev", "rollbackRef": "runtime/prophet-python-ml/0.0.1"},
+            "promotion": {"channel": profile.channel, "rollbackRef": profile.rollback_ref},
         },
     }
 
 
 def main() -> int:
     BUILD_DIR.mkdir(parents=True, exist_ok=True)
-    output = BUILD_DIR / "prophet-python-ml.runtime-asset.json"
-    output.write_text(json.dumps(runtime_asset(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    print(json.dumps({"written": [str(output)]}, indent=2, sort_keys=True))
+    written: list[str] = []
+    for profile in PROFILES:
+        output = BUILD_DIR / f"{profile.name}.runtime-asset.json"
+        write_json(output, runtime_asset(profile))
+        written.append(str(output))
+    print(json.dumps({"written": written}, indent=2, sort_keys=True))
     return 0
 
 

--- a/tools/validate_runtime_sidecars.py
+++ b/tools/validate_runtime_sidecars.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILD_DIR = ROOT / "build" / "runtime-assets"
+PROFILES = ["prophet-python-ml", "prophet-ray-ml", "prophet-beam-dataops"]
+SHA256_RE = re.compile(r"^sha256:[a-f0-9]{64}$")
+
+
+def fail(message: str) -> int:
+    print(f"ERR: {message}", file=sys.stderr)
+    return 1
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    require(path.exists(), f"missing {path}")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    require(isinstance(value, dict), f"{path} must contain a JSON object")
+    return value
+
+
+def digest_ok(value: str) -> bool:
+    return SHA256_RE.match(value) is not None
+
+
+def validate_profile(profile: str) -> None:
+    runtime = load_json(BUILD_DIR / f"{profile}.runtime-asset.json")
+    sbom = load_json(BUILD_DIR / f"{profile}.sbom.spdx.json")
+    scan = load_json(BUILD_DIR / f"{profile}.scan.json")
+    attestation = load_json(BUILD_DIR / f"{profile}.attestation.json")
+    signature = load_json(BUILD_DIR / f"{profile}.sigstore.bundle.json")
+
+    require(runtime["metadata"]["name"] == profile, f"{profile}: RuntimeAsset metadata.name mismatch")
+    artifact_names = {artifact["name"] for artifact in runtime["spec"]["artifacts"]}
+    for suffix in ["sbom.spdx.json", "scan.json", "attestation.json", "sigstore.bundle.json"]:
+        name = f"build/runtime-assets/{profile}.{suffix}"
+        require(name in artifact_names, f"{profile}: RuntimeAsset missing artifact {name}")
+
+    require(sbom.get("spdxVersion") == "SPDX-2.3", f"{profile}: SBOM SPDX version mismatch")
+    require(sbom.get("name") == profile, f"{profile}: SBOM name mismatch")
+    require(isinstance(sbom.get("packages"), list) and len(sbom["packages"]) >= 3, f"{profile}: SBOM must list runtime source artifacts")
+
+    require(scan.get("runtime") == profile, f"{profile}: scan runtime mismatch")
+    for key in ["vulnerability", "license", "policy"]:
+        require(scan.get(key) == "pass", f"{profile}: scan.{key} must be pass")
+    require(isinstance(scan.get("scannedArtifacts"), list) and scan["scannedArtifacts"], f"{profile}: scannedArtifacts missing")
+
+    require(attestation.get("runtime") == profile, f"{profile}: attestation runtime mismatch")
+    require(attestation.get("builderId") == "lattice-forge-demo-builder", f"{profile}: builderId mismatch")
+    require(attestation.get("predicateType") == "https://slsa.dev/provenance/v1", f"{profile}: predicateType mismatch")
+    require(isinstance(attestation.get("subject"), list) and attestation["subject"], f"{profile}: attestation subject missing")
+
+    require(signature.get("runtime") == profile, f"{profile}: signature runtime mismatch")
+    require(signature.get("type") == "sigstore", f"{profile}: signature type mismatch")
+    require(digest_ok(signature.get("subjectDigest", "")), f"{profile}: signature subjectDigest invalid")
+    require(digest_ok(signature.get("bundleDigest", "")), f"{profile}: signature bundleDigest invalid")
+    require(runtime["spec"]["signature"]["bundleRef"] == f"build/runtime-assets/{profile}.sigstore.bundle.json", f"{profile}: signature bundleRef mismatch")
+    require(runtime["spec"]["scan"] == {"vulnerability": "pass", "license": "pass", "policy": "pass"}, f"{profile}: RuntimeAsset scan summary mismatch")
+
+
+def main() -> int:
+    try:
+        for profile in PROFILES:
+            validate_profile(profile)
+    except Exception as exc:  # noqa: BLE001
+        return fail(str(exc))
+    print(json.dumps({"ok": True, "profiles": PROFILES}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Expands Lattice Forge runtime production beyond the original single RuntimeAsset emitter.

## Adds

- `prophet-ray-ml` runtime scaffold
- `prophet-beam-dataops` runtime scaffold
- conda-compatible lock placeholders for both new profiles
- Jupyter kernel metadata for both new profiles
- multi-profile RuntimeAsset emitter
- SBOM, scan, attestation, and signature sidecar emission
- sidecar validator
- Makefile validation for all emitted RuntimeAsset profiles and evidence sidecars

## Runtime profiles emitted

- `prophet-python-ml`
- `prophet-ray-ml`
- `prophet-beam-dataops`

## Validation

Expected:

```bash
make validate
```

## Tracking

Advances Lattice Forge runtime production for SocioProphet/prophet-platform#291.