### PR TITLE
Add RuntimeAsset promotion evidence gates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate runtime-candidates-validate runtime-asset-emit runtime-asset-validate runtime-sidecars-validate
+.PHONY: validate runtime-candidates-validate runtime-asset-emit runtime-asset-validate runtime-sidecars-validate runtime-promotion-manifest-emit runtime-promotion-manifest-validate
 
-validate: runtime-candidates-validate runtime-asset-validate runtime-sidecars-validate
+validate: runtime-candidates-validate runtime-asset-validate runtime-sidecars-validate runtime-promotion-manifest-validate
 	@echo "OK: validate"
 
 runtime-candidates-validate:
@@ -23,3 +23,9 @@ runtime-asset-validate: runtime-asset-emit
 
 runtime-sidecars-validate: runtime-asset-emit
 	./.venv/bin/python tools/validate_runtime_sidecars.py 2>/dev/null || python3 tools/validate_runtime_sidecars.py
+
+runtime-promotion-manifest-emit: runtime-asset-emit
+	./.venv/bin/python tools/emit_runtime_promotion_manifest.py 2>/dev/null || python3 tools/emit_runtime_promotion_manifest.py
+
+runtime-promotion-manifest-validate: runtime-promotion-manifest-emit
+	./.venv/bin/python tools/validate_runtime_promotion_manifest.py 2>/dev/null || python3 tools/validate_runtime_promotion_manifest.py

--- a/tools/emit_runtime_promotion_manifest.py
+++ b/tools/emit_runtime_promotion_manifest.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILD_DIR = ROOT / "build" / "runtime-assets"
+PROFILES = ["prophet-python-ml", "prophet-ray-ml", "prophet-beam-dataops"]
+OUTPUT = BUILD_DIR / "runtime-promotion-manifest.json"
+
+
+def digest_bytes(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def digest_file(path: Path) -> str:
+    return digest_bytes(path.read_bytes())
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def evidence_entry(path: Path, role: str) -> dict[str, str]:
+    return {
+        "role": role,
+        "uri": path.relative_to(ROOT).as_posix(),
+        "digest": digest_file(path),
+    }
+
+
+def profile_manifest(profile: str) -> dict[str, Any]:
+    runtime_path = BUILD_DIR / f"{profile}.runtime-asset.json"
+    runtime = load_json(runtime_path)
+    spec = runtime["spec"]
+    evidence = [
+        evidence_entry(runtime_path, "runtime-asset"),
+        evidence_entry(BUILD_DIR / f"{profile}.sbom.spdx.json", "sbom"),
+        evidence_entry(BUILD_DIR / f"{profile}.scan.json", "scan-report"),
+        evidence_entry(BUILD_DIR / f"{profile}.attestation.json", "attestation"),
+        evidence_entry(BUILD_DIR / f"{profile}.sigstore.bundle.json", "signature"),
+    ]
+    scan = load_json(BUILD_DIR / f"{profile}.scan.json")
+    signature = load_json(BUILD_DIR / f"{profile}.sigstore.bundle.json")
+    attestation = load_json(BUILD_DIR / f"{profile}.attestation.json")
+    promotion_channel = spec["promotion"]["channel"]
+    generated_gates = {
+        "requiredEvidencePresent": all((ROOT / item["uri"]).exists() for item in evidence),
+        "scanPass": scan.get("vulnerability") == "pass" and scan.get("license") == "pass" and scan.get("policy") == "pass",
+        "signaturePresent": signature.get("type") == "sigstore" and signature.get("bundleDigest", "").startswith("sha256:"),
+        "provenancePresent": attestation.get("predicateType") == "https://slsa.dev/provenance/v1",
+        "runtimeAssetReferencesSidecars": all(
+            item["uri"] in {artifact.get("uri") for artifact in spec.get("artifacts", [])}
+            for item in evidence
+            if item["role"] != "runtime-asset"
+        ),
+    }
+    stable_blockers = []
+    if promotion_channel != "stable":
+        stable_blockers.append("promotion.channel is not stable")
+    stable_blockers.append("external scanner and external signing authority evidence not yet attached")
+    return {
+        "runtimeAssetRef": f"runtime-asset:{profile}:0.1.0",
+        "runtimeName": profile,
+        "runtimeClass": spec["runtimeClass"],
+        "promotionChannel": promotion_channel,
+        "evidence": evidence,
+        "generatedEvidenceGates": generated_gates,
+        "devPromotionAllowed": all(generated_gates.values()) and promotion_channel == "dev",
+        "stablePromotionAllowed": False,
+        "stablePromotionBlockers": stable_blockers,
+        "policyRef": f"policy://runtime/{profile}-demo",
+    }
+
+
+def main() -> int:
+    profiles = [profile_manifest(profile) for profile in PROFILES]
+    payload = {
+        "apiVersion": "lattice.socioprophet.dev/v1",
+        "kind": "RuntimePromotionManifest",
+        "metadata": {
+            "name": "lattice-runtime-promotion-manifest",
+            "version": "0.1.0",
+            "generatedBy": "tools/emit_runtime_promotion_manifest.py",
+        },
+        "profiles": profiles,
+        "policy": {
+            "devPromotionRequiresGeneratedEvidence": True,
+            "stablePromotionRequiresExternalScanner": True,
+            "stablePromotionRequiresExternalSigningAuthority": True,
+            "stablePromotionRequiresHumanApproval": True,
+        },
+    }
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"written": str(OUTPUT)}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_runtime_promotion_manifest.py
+++ b/tools/validate_runtime_promotion_manifest.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILD_DIR = ROOT / "build" / "runtime-assets"
+MANIFEST = BUILD_DIR / "runtime-promotion-manifest.json"
+PROFILES = {
+    "runtime-asset:prophet-python-ml:0.1.0": "notebook",
+    "runtime-asset:prophet-ray-ml:0.1.0": "ray",
+    "runtime-asset:prophet-beam-dataops:0.1.0": "beam",
+}
+REQUIRED_EVIDENCE_ROLES = {"runtime-asset", "sbom", "scan-report", "attestation", "signature"}
+DIGEST = re.compile(r"^sha256:[a-f0-9]{64}$")
+
+
+def fail(message: str) -> int:
+    print(f"ERR: {message}", file=sys.stderr)
+    return 1
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    require(path.exists(), f"missing {path}")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    require(isinstance(value, dict), f"{path} must contain JSON object")
+    return value
+
+
+def digest_ok(value: str) -> bool:
+    return DIGEST.match(value) is not None
+
+
+def validate_profile(profile: dict[str, Any]) -> str:
+    ref = profile.get("runtimeAssetRef")
+    require(ref in PROFILES, f"unexpected runtimeAssetRef {ref}")
+    require(profile.get("runtimeClass") == PROFILES[ref], f"{ref}: runtimeClass mismatch")
+    require(profile.get("promotionChannel") == "dev", f"{ref}: promotionChannel must remain dev")
+    evidence = profile.get("evidence")
+    require(isinstance(evidence, list), f"{ref}: evidence must be list")
+    roles = {item.get("role") for item in evidence if isinstance(item, dict)}
+    require(roles == REQUIRED_EVIDENCE_ROLES, f"{ref}: evidence roles mismatch {roles}")
+    for item in evidence:
+        require(isinstance(item, dict), f"{ref}: evidence entries must be objects")
+        uri = item.get("uri")
+        digest = item.get("digest")
+        require(isinstance(uri, str) and uri, f"{ref}: evidence uri missing")
+        require((ROOT / uri).exists(), f"{ref}: evidence file missing {uri}")
+        require(isinstance(digest, str) and digest_ok(digest), f"{ref}: evidence digest invalid")
+    gates = profile.get("generatedEvidenceGates")
+    require(isinstance(gates, dict), f"{ref}: generatedEvidenceGates must be object")
+    for key in ["requiredEvidencePresent", "scanPass", "signaturePresent", "provenancePresent", "runtimeAssetReferencesSidecars"]:
+        require(gates.get(key) is True, f"{ref}: gate {key} must be true")
+    require(profile.get("devPromotionAllowed") is True, f"{ref}: devPromotionAllowed must be true")
+    require(profile.get("stablePromotionAllowed") is False, f"{ref}: stablePromotionAllowed must be false")
+    blockers = profile.get("stablePromotionBlockers")
+    require(isinstance(blockers, list) and blockers, f"{ref}: stablePromotionBlockers must be non-empty")
+    require(any("external scanner" in item for item in blockers), f"{ref}: stable promotion must require external scanner evidence")
+    require(any("external signing" in item for item in blockers), f"{ref}: stable promotion must require external signing evidence")
+    return ref
+
+
+def main() -> int:
+    try:
+        manifest = load_json(MANIFEST)
+        require(manifest.get("apiVersion") == "lattice.socioprophet.dev/v1", "apiVersion mismatch")
+        require(manifest.get("kind") == "RuntimePromotionManifest", "kind mismatch")
+        profiles = manifest.get("profiles")
+        require(isinstance(profiles, list), "profiles must be list")
+        refs = {validate_profile(profile) for profile in profiles if isinstance(profile, dict)}
+        require(refs == set(PROFILES), f"profile refs mismatch: {sorted(refs)}")
+        policy = manifest.get("policy")
+        require(isinstance(policy, dict), "policy must be object")
+        require(policy.get("devPromotionRequiresGeneratedEvidence") is True, "dev policy gate missing")
+        require(policy.get("stablePromotionRequiresExternalScanner") is True, "stable scanner gate missing")
+        require(policy.get("stablePromotionRequiresExternalSigningAuthority") is True, "stable signing gate missing")
+        require(policy.get("stablePromotionRequiresHumanApproval") is True, "stable approval gate missing")
+    except Exception as exc:  # noqa: BLE001
+        return fail(str(exc))
+    print(json.dumps({"ok": True, "validated": str(MANIFEST)}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds promotion evidence gates for Lattice Forge RuntimeAsset profiles.

## Adds

- `tools/emit_runtime_promotion_manifest.py`
- `tools/validate_runtime_promotion_manifest.py`
- Makefile validation wiring

## Promotion posture

- Dev promotion is allowed only when generated RuntimeAsset, SBOM, scan, attestation, and signature evidence are present and valid.
- Stable promotion remains explicitly blocked until external scanner evidence, external signing authority evidence, and human approval are attached.

## Runtime profiles covered

- `runtime-asset:prophet-python-ml:0.1.0`
- `runtime-asset:prophet-ray-ml:0.1.0`
- `runtime-asset:prophet-beam-dataops:0.1.0`

## Validation

Expected:

```bash
make validate
```

## Tracking

Advances runtime production for SocioProphet/prophet-platform#291.