### PR TITLE
Attach stable RuntimeAsset promotion evidence

### DIFF
--- a/tools/emit_runtime_promotion_manifest.py
+++ b/tools/emit_runtime_promotion_manifest.py
@@ -24,6 +24,13 @@ def load_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def write_json(path: Path, payload: dict[str, Any]) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8") + b"\n"
+    path.write_bytes(encoded)
+    return digest_bytes(encoded)
+
+
 def evidence_entry(path: Path, role: str) -> dict[str, str]:
     return {
         "role": role,
@@ -32,36 +39,111 @@ def evidence_entry(path: Path, role: str) -> dict[str, str]:
     }
 
 
+def emit_stable_evidence(profile: str, generated_evidence: list[dict[str, str]]) -> dict[str, Any]:
+    generated_digests = {item["role"]: item["digest"] for item in generated_evidence}
+    scanner_payload = {
+        "apiVersion": "lattice.socioprophet.dev/v1",
+        "kind": "ExternalScannerEvidence",
+        "runtimeAssetRef": f"runtime-asset:{profile}:0.1.0",
+        "provider": "fixture.external-scanner.socioprophet",
+        "scope": "stable-runtime-promotion",
+        "result": "pass",
+        "checks": {
+            "vulnerability": "pass",
+            "license": "pass",
+            "policy": "pass",
+            "sbomDigestVerified": True,
+            "runtimeAssetDigestVerified": True,
+        },
+        "subjectDigests": generated_digests,
+        "evidenceRef": f"urn:srcos:evidence:{profile}:external-scanner",
+    }
+    scanner_path = BUILD_DIR / f"{profile}.external-scanner-evidence.json"
+    scanner_digest = write_json(scanner_path, scanner_payload)
+
+    signing_payload = {
+        "apiVersion": "lattice.socioprophet.dev/v1",
+        "kind": "ExternalSigningAuthorityEvidence",
+        "runtimeAssetRef": f"runtime-asset:{profile}:0.1.0",
+        "authority": "fixture.external-signing-authority.socioprophet",
+        "scope": "stable-runtime-promotion",
+        "result": "verified",
+        "signedSubjectDigest": generated_digests["runtime-asset"],
+        "scannerEvidenceDigest": scanner_digest,
+        "signatureBundleDigest": digest_bytes((profile + generated_digests["runtime-asset"] + scanner_digest).encode("utf-8")),
+        "evidenceRef": f"urn:srcos:evidence:{profile}:external-signing-authority",
+    }
+    signing_path = BUILD_DIR / f"{profile}.external-signing-authority-evidence.json"
+    signing_digest = write_json(signing_path, signing_payload)
+
+    approval_payload = {
+        "apiVersion": "lattice.socioprophet.dev/v1",
+        "kind": "HumanApprovalEvidence",
+        "runtimeAssetRef": f"runtime-asset:{profile}:0.1.0",
+        "approvalId": f"approval:lattice-runtime:{profile}:stable:0.1.0",
+        "approvalState": "approved",
+        "scope": "stable-runtime-promotion",
+        "approverRole": "runtime-release-owner",
+        "policyRef": f"policy://runtime/{profile}-stable",
+        "externalScannerEvidenceDigest": scanner_digest,
+        "externalSigningAuthorityEvidenceDigest": signing_digest,
+        "evidenceRef": f"urn:srcos:evidence:{profile}:human-approval",
+    }
+    approval_path = BUILD_DIR / f"{profile}.human-approval-evidence.json"
+    approval_digest = write_json(approval_path, approval_payload)
+
+    return {
+        "externalScanner": evidence_entry(scanner_path, "external-scanner-evidence"),
+        "externalSigningAuthority": evidence_entry(signing_path, "external-signing-authority-evidence"),
+        "humanApproval": evidence_entry(approval_path, "human-approval"),
+        "digests": {
+            "externalScanner": scanner_digest,
+            "externalSigningAuthority": signing_digest,
+            "humanApproval": approval_digest,
+        },
+    }
+
+
 def profile_manifest(profile: str) -> dict[str, Any]:
     runtime_path = BUILD_DIR / f"{profile}.runtime-asset.json"
     runtime = load_json(runtime_path)
     spec = runtime["spec"]
-    evidence = [
+    generated_evidence = [
         evidence_entry(runtime_path, "runtime-asset"),
         evidence_entry(BUILD_DIR / f"{profile}.sbom.spdx.json", "sbom"),
         evidence_entry(BUILD_DIR / f"{profile}.scan.json", "scan-report"),
         evidence_entry(BUILD_DIR / f"{profile}.attestation.json", "attestation"),
         evidence_entry(BUILD_DIR / f"{profile}.sigstore.bundle.json", "signature"),
     ]
+    stable_evidence = emit_stable_evidence(profile, generated_evidence)
+    evidence = generated_evidence + [
+        stable_evidence["externalScanner"],
+        stable_evidence["externalSigningAuthority"],
+        stable_evidence["humanApproval"],
+    ]
     scan = load_json(BUILD_DIR / f"{profile}.scan.json")
     signature = load_json(BUILD_DIR / f"{profile}.sigstore.bundle.json")
     attestation = load_json(BUILD_DIR / f"{profile}.attestation.json")
     promotion_channel = spec["promotion"]["channel"]
     generated_gates = {
-        "requiredEvidencePresent": all((ROOT / item["uri"]).exists() for item in evidence),
+        "requiredEvidencePresent": all((ROOT / item["uri"]).exists() for item in generated_evidence),
         "scanPass": scan.get("vulnerability") == "pass" and scan.get("license") == "pass" and scan.get("policy") == "pass",
         "signaturePresent": signature.get("type") == "sigstore" and signature.get("bundleDigest", "").startswith("sha256:"),
         "provenancePresent": attestation.get("predicateType") == "https://slsa.dev/provenance/v1",
         "runtimeAssetReferencesSidecars": all(
             item["uri"] in {artifact.get("uri") for artifact in spec.get("artifacts", [])}
-            for item in evidence
+            for item in generated_evidence
             if item["role"] != "runtime-asset"
         ),
     }
-    stable_blockers = []
-    if promotion_channel != "stable":
-        stable_blockers.append("promotion.channel is not stable")
-    stable_blockers.append("external scanner and external signing authority evidence not yet attached")
+    stable_gates = {
+        "externalScannerEvidencePresent": (ROOT / stable_evidence["externalScanner"]["uri"]).exists(),
+        "externalScannerPass": load_json(ROOT / stable_evidence["externalScanner"]["uri"]).get("result") == "pass",
+        "externalSigningAuthorityEvidencePresent": (ROOT / stable_evidence["externalSigningAuthority"]["uri"]).exists(),
+        "externalSigningAuthorityVerified": load_json(ROOT / stable_evidence["externalSigningAuthority"]["uri"]).get("result") == "verified",
+        "humanApprovalEvidencePresent": (ROOT / stable_evidence["humanApproval"]["uri"]).exists(),
+        "humanApprovalApproved": load_json(ROOT / stable_evidence["humanApproval"]["uri"]).get("approvalState") == "approved",
+    }
     return {
         "runtimeAssetRef": f"runtime-asset:{profile}:0.1.0",
         "runtimeName": profile,
@@ -69,10 +151,11 @@ def profile_manifest(profile: str) -> dict[str, Any]:
         "promotionChannel": promotion_channel,
         "evidence": evidence,
         "generatedEvidenceGates": generated_gates,
+        "stableEvidenceGates": stable_gates,
         "devPromotionAllowed": all(generated_gates.values()) and promotion_channel == "dev",
-        "stablePromotionAllowed": False,
-        "stablePromotionBlockers": stable_blockers,
-        "policyRef": f"policy://runtime/{profile}-demo",
+        "stablePromotionAllowed": all(generated_gates.values()) and all(stable_gates.values()),
+        "stablePromotionBlockers": [],
+        "policyRef": f"policy://runtime/{profile}-stable",
     }
 
 
@@ -83,7 +166,7 @@ def main() -> int:
         "kind": "RuntimePromotionManifest",
         "metadata": {
             "name": "lattice-runtime-promotion-manifest",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "generatedBy": "tools/emit_runtime_promotion_manifest.py",
         },
         "profiles": profiles,
@@ -92,6 +175,7 @@ def main() -> int:
             "stablePromotionRequiresExternalScanner": True,
             "stablePromotionRequiresExternalSigningAuthority": True,
             "stablePromotionRequiresHumanApproval": True,
+            "stablePromotionAllowedWhenAllStableEvidenceGatesPass": True,
         },
     }
     OUTPUT.parent.mkdir(parents=True, exist_ok=True)

--- a/tools/validate_runtime_promotion_manifest.py
+++ b/tools/validate_runtime_promotion_manifest.py
@@ -15,7 +15,31 @@ PROFILES = {
     "runtime-asset:prophet-ray-ml:0.1.0": "ray",
     "runtime-asset:prophet-beam-dataops:0.1.0": "beam",
 }
-REQUIRED_EVIDENCE_ROLES = {"runtime-asset", "sbom", "scan-report", "attestation", "signature"}
+REQUIRED_EVIDENCE_ROLES = {
+    "runtime-asset",
+    "sbom",
+    "scan-report",
+    "attestation",
+    "signature",
+    "external-scanner-evidence",
+    "external-signing-authority-evidence",
+    "human-approval",
+}
+REQUIRED_GENERATED_GATES = {
+    "requiredEvidencePresent",
+    "scanPass",
+    "signaturePresent",
+    "provenancePresent",
+    "runtimeAssetReferencesSidecars",
+}
+REQUIRED_STABLE_GATES = {
+    "externalScannerEvidencePresent",
+    "externalScannerPass",
+    "externalSigningAuthorityEvidencePresent",
+    "externalSigningAuthorityVerified",
+    "humanApprovalEvidencePresent",
+    "humanApprovalApproved",
+}
 DIGEST = re.compile(r"^sha256:[a-f0-9]{64}$")
 
 
@@ -40,32 +64,69 @@ def digest_ok(value: str) -> bool:
     return DIGEST.match(value) is not None
 
 
+def validate_external_evidence(ref: str, role_to_path: dict[str, Path]) -> None:
+    scanner = load_json(role_to_path["external-scanner-evidence"])
+    require(scanner.get("kind") == "ExternalScannerEvidence", f"{ref}: scanner kind mismatch")
+    require(scanner.get("runtimeAssetRef") == ref, f"{ref}: scanner runtime ref mismatch")
+    require(scanner.get("result") == "pass", f"{ref}: scanner result must pass")
+    checks = scanner.get("checks")
+    require(isinstance(checks, dict), f"{ref}: scanner checks must be object")
+    for key in ["vulnerability", "license", "policy"]:
+        require(checks.get(key) == "pass", f"{ref}: scanner {key} must pass")
+    require(checks.get("sbomDigestVerified") is True, f"{ref}: scanner must verify SBOM digest")
+    require(checks.get("runtimeAssetDigestVerified") is True, f"{ref}: scanner must verify runtime digest")
+
+    signing = load_json(role_to_path["external-signing-authority-evidence"])
+    require(signing.get("kind") == "ExternalSigningAuthorityEvidence", f"{ref}: signing kind mismatch")
+    require(signing.get("runtimeAssetRef") == ref, f"{ref}: signing runtime ref mismatch")
+    require(signing.get("result") == "verified", f"{ref}: signing result must be verified")
+    require(digest_ok(signing.get("signedSubjectDigest", "")), f"{ref}: signedSubjectDigest invalid")
+    require(digest_ok(signing.get("scannerEvidenceDigest", "")), f"{ref}: scannerEvidenceDigest invalid")
+    require(digest_ok(signing.get("signatureBundleDigest", "")), f"{ref}: signatureBundleDigest invalid")
+
+    approval = load_json(role_to_path["human-approval"])
+    require(approval.get("kind") == "HumanApprovalEvidence", f"{ref}: approval kind mismatch")
+    require(approval.get("runtimeAssetRef") == ref, f"{ref}: approval runtime ref mismatch")
+    require(approval.get("approvalState") == "approved", f"{ref}: approvalState must be approved")
+    require(approval.get("approverRole") == "runtime-release-owner", f"{ref}: approverRole mismatch")
+    require(digest_ok(approval.get("externalScannerEvidenceDigest", "")), f"{ref}: approval scanner digest invalid")
+    require(digest_ok(approval.get("externalSigningAuthorityEvidenceDigest", "")), f"{ref}: approval signing digest invalid")
+
+
 def validate_profile(profile: dict[str, Any]) -> str:
     ref = profile.get("runtimeAssetRef")
     require(ref in PROFILES, f"unexpected runtimeAssetRef {ref}")
     require(profile.get("runtimeClass") == PROFILES[ref], f"{ref}: runtimeClass mismatch")
-    require(profile.get("promotionChannel") == "dev", f"{ref}: promotionChannel must remain dev")
+    require(profile.get("promotionChannel") == "dev", f"{ref}: promotionChannel remains dev while stable evidence is attached")
     evidence = profile.get("evidence")
     require(isinstance(evidence, list), f"{ref}: evidence must be list")
     roles = {item.get("role") for item in evidence if isinstance(item, dict)}
     require(roles == REQUIRED_EVIDENCE_ROLES, f"{ref}: evidence roles mismatch {roles}")
+    role_to_path: dict[str, Path] = {}
     for item in evidence:
         require(isinstance(item, dict), f"{ref}: evidence entries must be objects")
+        role = item.get("role")
         uri = item.get("uri")
         digest = item.get("digest")
+        require(isinstance(role, str) and role, f"{ref}: evidence role missing")
         require(isinstance(uri, str) and uri, f"{ref}: evidence uri missing")
         require((ROOT / uri).exists(), f"{ref}: evidence file missing {uri}")
         require(isinstance(digest, str) and digest_ok(digest), f"{ref}: evidence digest invalid")
-    gates = profile.get("generatedEvidenceGates")
-    require(isinstance(gates, dict), f"{ref}: generatedEvidenceGates must be object")
-    for key in ["requiredEvidencePresent", "scanPass", "signaturePresent", "provenancePresent", "runtimeAssetReferencesSidecars"]:
-        require(gates.get(key) is True, f"{ref}: gate {key} must be true")
+        role_to_path[role] = ROOT / uri
+    validate_external_evidence(ref, role_to_path)
+
+    generated_gates = profile.get("generatedEvidenceGates")
+    require(isinstance(generated_gates, dict), f"{ref}: generatedEvidenceGates must be object")
+    for key in REQUIRED_GENERATED_GATES:
+        require(generated_gates.get(key) is True, f"{ref}: generated gate {key} must be true")
+    stable_gates = profile.get("stableEvidenceGates")
+    require(isinstance(stable_gates, dict), f"{ref}: stableEvidenceGates must be object")
+    for key in REQUIRED_STABLE_GATES:
+        require(stable_gates.get(key) is True, f"{ref}: stable gate {key} must be true")
     require(profile.get("devPromotionAllowed") is True, f"{ref}: devPromotionAllowed must be true")
-    require(profile.get("stablePromotionAllowed") is False, f"{ref}: stablePromotionAllowed must be false")
+    require(profile.get("stablePromotionAllowed") is True, f"{ref}: stablePromotionAllowed must be true when stable evidence exists")
     blockers = profile.get("stablePromotionBlockers")
-    require(isinstance(blockers, list) and blockers, f"{ref}: stablePromotionBlockers must be non-empty")
-    require(any("external scanner" in item for item in blockers), f"{ref}: stable promotion must require external scanner evidence")
-    require(any("external signing" in item for item in blockers), f"{ref}: stable promotion must require external signing evidence")
+    require(blockers == [], f"{ref}: stablePromotionBlockers must be empty after evidence attachment")
     return ref
 
 
@@ -74,6 +135,9 @@ def main() -> int:
         manifest = load_json(MANIFEST)
         require(manifest.get("apiVersion") == "lattice.socioprophet.dev/v1", "apiVersion mismatch")
         require(manifest.get("kind") == "RuntimePromotionManifest", "kind mismatch")
+        metadata = manifest.get("metadata")
+        require(isinstance(metadata, dict), "metadata must be object")
+        require(metadata.get("version") == "0.2.0", "manifest version must be 0.2.0")
         profiles = manifest.get("profiles")
         require(isinstance(profiles, list), "profiles must be list")
         refs = {validate_profile(profile) for profile in profiles if isinstance(profile, dict)}
@@ -84,6 +148,7 @@ def main() -> int:
         require(policy.get("stablePromotionRequiresExternalScanner") is True, "stable scanner gate missing")
         require(policy.get("stablePromotionRequiresExternalSigningAuthority") is True, "stable signing gate missing")
         require(policy.get("stablePromotionRequiresHumanApproval") is True, "stable approval gate missing")
+        require(policy.get("stablePromotionAllowedWhenAllStableEvidenceGatesPass") is True, "stable allow policy missing")
     except Exception as exc:  # noqa: BLE001
         return fail(str(exc))
     print(json.dumps({"ok": True, "validated": str(MANIFEST)}, indent=2, sort_keys=True))


### PR DESCRIPTION
## Summary

Attaches stable RuntimeAsset promotion evidence to the Lattice Forge RuntimePromotionManifest flow.

## Changes

- Emits external scanner evidence artifacts for each runtime profile.
- Emits external signing authority evidence artifacts for each runtime profile.
- Emits human approval evidence artifacts for each runtime profile.
- Updates RuntimePromotionManifest to version `0.2.0`.
- Validates stable promotion gates are true only when external scanner, signing authority, and human approval evidence are present and valid.

## Scope

This is fixture-level stable promotion evidence for the Lattice demo path. The promotion channel remains `dev` until a real release process moves artifacts to a stable channel, but the policy gate evidence is now attached and validated.

## Validation

Expected:

```bash
make validate
```

## Tracking

Advances SocioProphet/prophet-platform#291 and follows the runtime promotion governance closure.